### PR TITLE
Fjern Nav-Consumer-Token header

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,31 @@
+name: Publish Snapshot
+
+on:
+  push:
+    branches:
+      - dev/**
+
+jobs:
+  publish-snapshot:
+    env:
+      ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Get Version
+        run:  |
+          echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)"
+          echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)" >> $GITHUB_ENV
+      - name: Publish artifact
+        if: ${{ endsWith(env.CURRENT_VERSION, '-SNAPSHOT') }}
+        run: ./gradlew publish

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Henter arbeidsforhold fra Arbeidsgiver- og arbeidstakerregisteret ([aareg](https://navikt.github.io/aareg/)).
 
+### Bygg / Release
+
+For å publisere snapshots, lag en branch som starter med dev/
+Bump version i gradle.properties og inkluder -SNAPSHOT: version=1.2.3-SNAPSHOT
+
+Github Action vil nå publisere SNAPSHOT-version ved push til branch
+
+For å release:
+Fjern "-SNAPSHOT" fra version og merge / push til main-branch.
+
 ### Bruk av helsearbeidsgiver-aareg-client
 
 ***gradle.build.kts***

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 }
 
 group = "no.nav.helsearbeidsgiver"
-version = "0.6.0"
 
 kotlin {
     compilerOptions {
@@ -36,6 +35,10 @@ tasks {
             html.outputLocation.set(layout.buildDirectory.dir("jacocoHtml"))
         }
     }
+}
+
+tasks.register("printVersion") {
+    printVersion()
 }
 
 repositories {
@@ -89,3 +92,5 @@ fun RepositoryHandler.mavenNav(repo: String): MavenArtifactRepository {
         }
     }
 }
+
+fun printVersion() = println(version)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 kotlin.code.style=official
 
+version=0.6.1-SNAPSHOT
+
 # Plugin versions
 kotlinVersion=1.9.10
 kotlinterVersion=3.16.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-version=0.6.1-SNAPSHOT
+version=0.7.0
 
 # Plugin versions
 kotlinVersion=1.9.10

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
@@ -29,7 +29,6 @@ class AaregClient(
                 contentType(ContentType.Application.Json)
                 bearerAuth(token)
                 header("X-Correlation-ID", callId)
-                header("Nav-Consumer-Token", "Bearer $token")
                 header("Nav-Personident", ident)
             }.also {
                 sikkerLogger.debug("Svar fra aareg-API: " + it.bodyAsText())


### PR DESCRIPTION
**Bakgrunn**
Da jeg begynte å skrive oss vekk fra å bruke vår egen proxy for å kommunisere fra `Fritak` og `Simba` mot `Aareg`, så fikk jeg denne feilen fra `Aareg`: "Nav-Consumer-Token skal ikke sendes inn dersom det benyttes authorization token fra AzureAD eller TokenX".

**Løsning**
1. Fjern `Nav-Consumer-Token`-headeren.
2. Legg til samme publish-snapshot-workflow som i `hag-domene-inntektsmelding`(https://github.com/navikt/hag-domene-inntektsmelding/pull/24)