### PR TITLE
Legg til retry og timeout

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/HttpUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/HttpUtils.kt
@@ -3,6 +3,9 @@ package no.nav.helsearbeidsgiver.aareg
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.apache5.Apache5
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpRequestRetryConfig
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
@@ -16,4 +19,23 @@ internal fun HttpClientConfig<*>.configure() {
     install(ContentNegotiation) {
         json(jsonConfig)
     }
+
+    install(HttpRequestRetry) { configureRetry() }
+
+    install(HttpTimeout) {
+        connectTimeoutMillis = 500
+        requestTimeoutMillis = 500
+        socketTimeoutMillis = 500
+    }
+}
+
+internal fun HttpRequestRetryConfig.configureRetry() {
+    retryOnException(
+        maxRetries = 5,
+        retryOnTimeout = true,
+    )
+    constantDelay(
+        millis = 500,
+        randomizationMs = 500,
+    )
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/MockUtils.kt
@@ -1,13 +1,17 @@
 package no.nav.helsearbeidsgiver.aareg
 
+import io.kotest.core.test.testCoroutineScheduler
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.mockk.every
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
 import no.nav.helsearbeidsgiver.utils.test.resource.readResource
@@ -18,16 +22,39 @@ object MockResponse {
     val error = "error.json".readResource()
 }
 
-fun mockAaregClient(content: String, statusCode: HttpStatusCode = HttpStatusCode.OK): AaregClient {
-    val mockEngine = MockEngine {
-        respond(
-            content = content,
-            status = statusCode,
-            headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+@OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
+fun mockAaregClient(vararg responses: Pair<HttpStatusCode, String>): AaregClient {
+    val mockEngine = MockEngine.create {
+        reuseHandlers = false
+        requestHandlers.addAll(
+            responses.map { (status, content) ->
+                {
+                    if (content == "timeout") {
+                        // Skrur den virtuelle klokka fremover, nok til at timeout forårsakes
+                        dispatcher.shouldNotBeNull().testCoroutineScheduler.advanceTimeBy(1)
+                    }
+                    respond(
+                        content = content,
+                        status = status,
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                    )
+                }
+            },
         )
     }
 
-    val mockHttpClient = HttpClient(mockEngine) { configure() }
+    val mockHttpClient = HttpClient(mockEngine) {
+        configure()
+
+        // Overstyr delay for å unngå at testene bruker lang tidAdd commentMore actions
+        install(HttpRequestRetry) {
+            configureRetry()
+            constantDelay(
+                millis = 1,
+                randomizationMs = 1,
+            )
+        }
+    }
 
     return mockStatic(::createHttpClient) {
         every { createHttpClient() } returns mockHttpClient

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/MockUtils.kt
@@ -46,7 +46,7 @@ fun mockAaregClient(vararg responses: Pair<HttpStatusCode, String>): AaregClient
     val mockHttpClient = HttpClient(mockEngine) {
         configure()
 
-        // Overstyr delay for å unngå at testene bruker lang tidAdd commentMore actions
+        // Overstyr delay for å unngå at testene bruker lang tid
         install(HttpRequestRetry) {
             configureRetry()
             constantDelay(


### PR DESCRIPTION
Timeout er basert på data på Grafana som tilsier at et kall vanligvis tar 200 ms.

https://grafana.nav.cloud.nais.io/d/rZtfrreVz/simba-inntektsmelding?orgId=1&from=now-7d&to=now&timezone=browser&var-env=000000021