### PR TITLE
Unngå value class som funksjonsparameter

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
@@ -8,7 +8,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import no.nav.helsearbeidsgiver.utils.collection.mapKeysNotNull
-import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 /** Les om API-et til Aareg [her](https://navikt.github.io/aareg/tjenester/integrasjon/api/). */
@@ -20,13 +19,13 @@ class AaregClient(
     private val httpClient = createHttpClient()
     private val cache = LocalCache<List<Arbeidsforhold>>(cacheConfig)
 
-    suspend fun hentAnsettelsesperioder(fnr: Fnr, callId: String): Map<Orgnr, Set<Periode>> =
-        cache.getOrPut(fnr.verdi) {
+    suspend fun hentAnsettelsesperioder(fnr: String, callId: String): Map<Orgnr, Set<Periode>> =
+        cache.getOrPut(fnr) {
             httpClient.get(url) {
                 contentType(ContentType.Application.Json)
                 bearerAuth(getAccessToken())
                 header("X-Correlation-ID", callId)
-                header("Nav-Personident", fnr.verdi)
+                header("Nav-Personident", fnr)
             }.body<List<Arbeidsforhold>>()
         }
             .groupBy { it.arbeidsgiver.organisasjonsnummer }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
@@ -18,7 +18,7 @@ class AaregClientTest : FunSpec({
 
     test("gir ikke-tom liste med arbeidsforhold") {
         val response = mockAaregClient(HttpStatusCode.OK to MockResponse.arbeidsforhold)
-            .hentAnsettelsesperioder(Fnr("22018520056"), "call-id")
+            .hentAnsettelsesperioder("22018520056", "call-id")
 
         val expectedAnsettelsesperioder =
             mapOf(
@@ -34,14 +34,14 @@ class AaregClientTest : FunSpec({
     test("kaster exception ved uventet JSON") {
         shouldThrowExactly<JsonConvertException> {
             mockAaregClient(HttpStatusCode.OK to MockResponse.error)
-                .hentAnsettelsesperioder(Fnr.genererGyldig(), "54-56 That's My Number")
+                .hentAnsettelsesperioder(Fnr.genererGyldig().verdi, "54-56 That's My Number")
         }
     }
 
     test("feiler ved 4xx-feil") {
         shouldThrowExactly<ClientRequestException> {
             mockAaregClient(HttpStatusCode.BadRequest to "")
-                .hentAnsettelsesperioder(Fnr.genererGyldig(), "mock call-id")
+                .hentAnsettelsesperioder(Fnr.genererGyldig().verdi, "mock call-id")
         }
     }
 
@@ -54,7 +54,7 @@ class AaregClientTest : FunSpec({
                 HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.OK to MockResponse.arbeidsforhold,
-            ).hentAnsettelsesperioder(Fnr.genererGyldig(), "mock call-id")
+            ).hentAnsettelsesperioder(Fnr.genererGyldig().verdi, "mock call-id")
         }
     }
 
@@ -67,7 +67,7 @@ class AaregClientTest : FunSpec({
                 HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.InternalServerError to "",
-            ).hentAnsettelsesperioder(Fnr.genererGyldig(), "mock call-id")
+            ).hentAnsettelsesperioder(Fnr.genererGyldig().verdi, "mock call-id")
         }
     }
 
@@ -80,7 +80,7 @@ class AaregClientTest : FunSpec({
                 HttpStatusCode.OK to "timeout",
                 HttpStatusCode.OK to "timeout",
                 HttpStatusCode.OK to MockResponse.arbeidsforhold,
-            ).hentAnsettelsesperioder(Fnr.genererGyldig(), "mock call-id")
+            ).hentAnsettelsesperioder(Fnr.genererGyldig().verdi, "mock call-id")
         }
     }
 })


### PR DESCRIPTION
Value classes med init requirements, som `Fnr`, spiller dårlig på lag med MockK, som brukere av denne pakken benytter. Unngår bruk av `Fnr` som funksjonsparameter enn så lenge.