### PR TITLE
Fiks test for timeout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesVersion")
     testImplementation("org.slf4j:slf4j-simple:$slf4jVersion")
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/MockUtils.kt
@@ -1,7 +1,5 @@
 package no.nav.helsearbeidsgiver.aareg
 
-import io.kotest.core.test.testCoroutineScheduler
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -10,7 +8,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.mockk.every
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
 import no.nav.helsearbeidsgiver.utils.test.resource.readResource
@@ -21,7 +19,6 @@ object MockResponse {
     val error = "error.json".readResource()
 }
 
-@OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
 fun mockAaregClient(vararg responses: Pair<HttpStatusCode, String>): AaregClient {
     val mockEngine = MockEngine.create {
         reuseHandlers = false
@@ -29,8 +26,7 @@ fun mockAaregClient(vararg responses: Pair<HttpStatusCode, String>): AaregClient
             responses.map { (status, content) ->
                 {
                     if (content == "timeout") {
-                        // Skrur den virtuelle klokka fremover, nok til at timeout forårsakes
-                        dispatcher.shouldNotBeNull().testCoroutineScheduler.advanceTimeBy(1)
+                        delay(600)
                     }
                     respond(
                         content = content,


### PR DESCRIPTION
Den fancy testfunksjonen `advanceTimeBy` fungerte ikke som planlagt, så bytter den ut med en helt vanlig `delay`.