### PR TITLE
Øker http-timeout til 10 sekunder

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-version=1.0.4
+version=1.0.5
 
 # Plugin versions
 kotlinVersion=2.0.21

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/HttpUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/HttpUtils.kt
@@ -21,7 +21,7 @@ internal fun HttpClientConfig<*>.configure() {
 
     install(HttpRequestRetry) {
         retryOnException(
-            maxRetries = 5,
+            maxRetries = 3,
             retryOnTimeout = true,
         )
         constantDelay(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/HttpUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/HttpUtils.kt
@@ -31,8 +31,8 @@ internal fun HttpClientConfig<*>.configure() {
     }
 
     install(HttpTimeout) {
-        connectTimeoutMillis = 500
-        requestTimeoutMillis = 500
-        socketTimeoutMillis = 500
+        connectTimeoutMillis = 10000
+        requestTimeoutMillis = 10000
+        socketTimeoutMillis = 10000
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
@@ -117,17 +117,17 @@ class AaregClientTest : FunSpec({
     }
 
     test("kall feiler og prøver på nytt ved timeout") {
-        val mockAaregClient =
-            mockAaregClient(
-                HttpStatusCode.OK to "timeout",
-                HttpStatusCode.OK to "timeout",
-                HttpStatusCode.OK to "timeout",
-                HttpStatusCode.OK to "timeout",
-                HttpStatusCode.OK to "timeout",
-                HttpStatusCode.OK to MockResponse.arbeidsforhold,
-            )
+        fun test() = runTest {
+            val mockAaregClient =
+                mockAaregClient(
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to MockResponse.arbeidsforhold,
+                )
 
-        runTest {
             shouldNotThrowAny {
                 mockAaregClient.hentAnsettelsesperioder(Fnr.genererGyldig().verdi, "mock call-id")
             }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
@@ -78,11 +78,9 @@ class AaregClientTest : FunSpec({
         e.response.status shouldBe HttpStatusCode.BadRequest
     }
 
-    test("lykkes ved færre 5xx-feil enn max retries (5)") {
+    test("lykkes ved færre 5xx-feil enn max retries (3)") {
         val mockAaregClient =
             mockAaregClient(
-                HttpStatusCode.InternalServerError to "",
-                HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.InternalServerError to "",
@@ -96,11 +94,9 @@ class AaregClientTest : FunSpec({
         }
     }
 
-    test("feiler ved flere 5xx-feil enn max retries (5)") {
+    test("feiler ved flere 5xx-feil enn max retries (3)") {
         val mockAaregClient =
             mockAaregClient(
-                HttpStatusCode.InternalServerError to "",
-                HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.InternalServerError to "",
                 HttpStatusCode.InternalServerError to "",
@@ -117,17 +113,15 @@ class AaregClientTest : FunSpec({
     }
 
     test("kall feiler og prøver på nytt ved timeout") {
-        fun test() = runTest {
-            val mockAaregClient =
-                mockAaregClient(
-                    HttpStatusCode.OK to "timeout",
-                    HttpStatusCode.OK to "timeout",
-                    HttpStatusCode.OK to "timeout",
-                    HttpStatusCode.OK to "timeout",
-                    HttpStatusCode.OK to "timeout",
-                    HttpStatusCode.OK to MockResponse.arbeidsforhold,
-                )
-
+        // TODO: runTest skipper ikke delay i mock-klienten, så denne testen tar 3*10 sekunder å kjøre inntil vi finner en skikkelig løsning
+        val mockAaregClient =
+            mockAaregClient(
+                HttpStatusCode.OK to "timeout",
+                HttpStatusCode.OK to "timeout",
+                HttpStatusCode.OK to "timeout",
+                HttpStatusCode.OK to MockResponse.arbeidsforhold,
+            )
+        runTest {
             shouldNotThrowAny {
                 mockAaregClient.hentAnsettelsesperioder(Fnr.genererGyldig().verdi, "mock call-id")
             }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/MockUtils.kt
@@ -26,7 +26,7 @@ fun mockAaregClient(vararg responses: Pair<HttpStatusCode, String>): AaregClient
             responses.map { (status, content) ->
                 {
                     if (content == "timeout") {
-                        delay(600)
+                        delay(10100)
                     }
                     respond(
                         content = content,


### PR DESCRIPTION
Lagt inn en TODO på timeoutTest; delay blir ikke ignorert.
Forsøk på fix gjorde at testen gikk grønt også når den ikke skulle virket, så inntil videre blir det å beholde as-is, med lang kjøretid på timeout-testen.