### PR TITLE
Ta med flere felter for faisu oversikt

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=2.0.0
+version=2.1.0
 
 # Plugin versions
 kotlinVersion=2.2.20

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
@@ -39,18 +39,16 @@ class AaregClient(
             .mapValues { (_, arbeidsforholdListe) ->
                 arbeidsforholdListe
                     .map {
+                        val gjeldendeDetalj =
+                            it.ansettelsesdetaljer?.firstOrNull { detalj ->
+                                detalj.rapporteringsmaaneder?.til == null
+                            }
                         Ansettelsesforhold(
                             startdato = it.ansettelsesperiode.startdato,
                             sluttdato = it.ansettelsesperiode.sluttdato,
-                            detaljer =
-                                it.ansettelsesdetaljer
-                                    ?.map { detalj ->
-                                        Ansettelsesdetaljer(
-                                            yrkesKode = detalj.yrke?.kode,
-                                            yrkesBeskrivelse = detalj.yrke?.beskrivelse,
-                                            stillingsprosent = detalj.avtaltStillingsprosent,
-                                        )
-                                    }.orEmpty(),
+                            yrkesKode = gjeldendeDetalj?.yrke?.kode,
+                            yrkesBeskrivelse = gjeldendeDetalj?.yrke?.beskrivelse,
+                            stillingsprosent = gjeldendeDetalj?.avtaltStillingsprosent,
                         )
                     }.toSet()
             }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
@@ -23,7 +23,42 @@ class AaregClient(
     suspend fun hentAnsettelsesperioder(
         fnr: String,
         callId: String,
+    ): Map<Orgnr, Set<Periode>> =
+        hentArbeidsforholdPerOrgnr(fnr, callId)
+            .mapValues { (_, arbeidsforholdListe) ->
+                arbeidsforholdListe
+                    .map { Periode(fom = it.ansettelsesperiode.startdato, tom = it.ansettelsesperiode.sluttdato) }
+                    .toSet()
+            }
+
+    suspend fun hentAnsettelsesinfo(
+        fnr: String,
+        callId: String,
     ): Map<Orgnr, Set<Ansettelsesinfo>> =
+        hentArbeidsforholdPerOrgnr(fnr, callId)
+            .mapValues { (_, arbeidsforholdListe) ->
+                arbeidsforholdListe
+                    .map {
+                        Ansettelsesinfo(
+                            startdato = it.ansettelsesperiode.startdato,
+                            sluttdato = it.ansettelsesperiode.sluttdato,
+                            detaljer =
+                                it.ansettelsesdetaljer
+                                    ?.map { detalj ->
+                                        Ansettelsesdetaljer(
+                                            yrkesKode = detalj.yrke?.kode,
+                                            yrkesBeskrivelse = detalj.yrke?.beskrivelse,
+                                            stillingsprosent = detalj.avtaltStillingsprosent,
+                                        )
+                                    }.orEmpty(),
+                        )
+                    }.toSet()
+            }
+
+    private suspend fun hentArbeidsforholdPerOrgnr(
+        fnr: String,
+        callId: String,
+    ): Map<Orgnr, List<Arbeidsforhold>> =
         cache
             .getOrPut(fnr) {
                 httpClient
@@ -40,15 +75,5 @@ class AaregClient(
                 } else {
                     null
                 }
-            }.mapValues { (_, arbeidsforholdListe) ->
-                arbeidsforholdListe
-                    .map {
-                        val detalj = it.ansettelsesdetaljer?.firstOrNull()
-                        Ansettelsesinfo(
-                            periode = Periode(fom = it.ansettelsesperiode.startdato, tom = it.ansettelsesperiode.sluttdato),
-                            yrkeskode = detalj?.yrke?.kode,
-                            stillingsprosent = detalj?.avtaltStillingsprosent,
-                        )
-                    }.toSet()
             }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
@@ -31,15 +31,15 @@ class AaregClient(
                     .toSet()
             }
 
-    suspend fun hentAnsettelsesinfo(
+    suspend fun hentAnsettelsesforhold(
         fnr: String,
         callId: String,
-    ): Map<Orgnr, Set<Ansettelsesinfo>> =
+    ): Map<Orgnr, Set<Ansettelsesforhold>> =
         hentArbeidsforholdPerOrgnr(fnr, callId)
             .mapValues { (_, arbeidsforholdListe) ->
                 arbeidsforholdListe
                     .map {
-                        Ansettelsesinfo(
+                        Ansettelsesforhold(
                             startdato = it.ansettelsesperiode.startdato,
                             sluttdato = it.ansettelsesperiode.sluttdato,
                             detaljer =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
@@ -23,7 +23,7 @@ class AaregClient(
     suspend fun hentAnsettelsesperioder(
         fnr: String,
         callId: String,
-    ): Map<Orgnr, Set<Periode>> =
+    ): Map<Orgnr, Set<Ansettelsesinfo>> =
         cache
             .getOrPut(fnr) {
                 httpClient
@@ -41,6 +41,14 @@ class AaregClient(
                     null
                 }
             }.mapValues { (_, arbeidsforholdListe) ->
-                arbeidsforholdListe.map { Periode(fom = it.ansettelsesperiode.startdato, tom = it.ansettelsesperiode.sluttdato) }.toSet()
+                arbeidsforholdListe
+                    .map {
+                        val detalj = it.ansettelsesdetaljer?.firstOrNull()
+                        Ansettelsesinfo(
+                            periode = Periode(fom = it.ansettelsesperiode.startdato, tom = it.ansettelsesperiode.sluttdato),
+                            yrkeskode = detalj?.yrke?.kode,
+                            stillingsprosent = detalj?.avtaltStillingsprosent,
+                        )
+                    }.toSet()
             }
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClient.kt
@@ -40,15 +40,15 @@ class AaregClient(
                 arbeidsforholdListe
                     .map {
                         val gjeldendeDetalj =
-                            it.ansettelsesdetaljer?.firstOrNull { detalj ->
+                            it.ansettelsesdetaljer.first { detalj ->
                                 detalj.rapporteringsmaaneder?.til == null
                             }
                         Ansettelsesforhold(
                             startdato = it.ansettelsesperiode.startdato,
                             sluttdato = it.ansettelsesperiode.sluttdato,
-                            yrkesKode = gjeldendeDetalj?.yrke?.kode,
-                            yrkesBeskrivelse = gjeldendeDetalj?.yrke?.beskrivelse,
-                            stillingsprosent = gjeldendeDetalj?.avtaltStillingsprosent,
+                            yrkesKode = gjeldendeDetalj.yrke?.kode,
+                            yrkesBeskrivelse = gjeldendeDetalj.yrke?.beskrivelse,
+                            stillingsprosent = gjeldendeDetalj.avtaltStillingsprosent,
                         )
                     }.toSet()
             }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Ansettelsesforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Ansettelsesforhold.kt
@@ -11,11 +11,6 @@ import java.time.LocalDate
 data class Ansettelsesforhold(
     val startdato: LocalDate,
     val sluttdato: LocalDate? = null,
-    val detaljer: List<Ansettelsesdetaljer> = emptyList(),
-)
-
-@Serializable
-data class Ansettelsesdetaljer(
     val yrkesKode: String? = null,
     val yrkesBeskrivelse: String? = null,
     val stillingsprosent: Double? = null,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Ansettelsesforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Ansettelsesforhold.kt
@@ -8,7 +8,7 @@ import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import java.time.LocalDate
 
 @Serializable
-data class Ansettelsesinfo(
+data class Ansettelsesforhold(
     val startdato: LocalDate,
     val sluttdato: LocalDate? = null,
     val detaljer: List<Ansettelsesdetaljer> = emptyList(),

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Ansettelsesinfo.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Ansettelsesinfo.kt
@@ -1,0 +1,10 @@
+package no.nav.helsearbeidsgiver.aareg
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Ansettelsesinfo(
+    val periode: Periode,
+    val yrkeskode: String? = null,
+    val stillingsprosent: Double? = null,
+)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Ansettelsesinfo.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Ansettelsesinfo.kt
@@ -1,10 +1,22 @@
+@file:UseSerializers(LocalDateSerializer::class)
+
 package no.nav.helsearbeidsgiver.aareg
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import java.time.LocalDate
 
 @Serializable
 data class Ansettelsesinfo(
-    val periode: Periode,
-    val yrkeskode: String? = null,
+    val startdato: LocalDate,
+    val sluttdato: LocalDate? = null,
+    val detaljer: List<Ansettelsesdetaljer> = emptyList(),
+)
+
+@Serializable
+data class Ansettelsesdetaljer(
+    val yrkesKode: String? = null,
+    val yrkesBeskrivelse: String? = null,
     val stillingsprosent: Double? = null,
 )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Arbeidsforhold.kt
@@ -12,11 +12,11 @@ import java.time.LocalDate
 internal data class Arbeidsforhold(
     val arbeidssted: Arbeidssted,
     val ansettelsesperiode: Ansettelsesperiode,
-    val ansettelsesdetaljer: List<Ansettelsesdetalj>? = null,
+    val ansettelsesdetaljer: List<AnsettelsesdetaljResponse>? = null,
 )
 
 @Serializable
-internal data class Ansettelsesdetalj(
+internal data class AnsettelsesdetaljResponse(
     val yrke: Yrke? = null,
     val avtaltStillingsprosent: Double? = null,
 )
@@ -24,6 +24,7 @@ internal data class Ansettelsesdetalj(
 @Serializable
 internal data class Yrke(
     val kode: String,
+    val beskrivelse: String? = null,
 )
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Arbeidsforhold.kt
@@ -12,6 +12,18 @@ import java.time.LocalDate
 internal data class Arbeidsforhold(
     val arbeidssted: Arbeidssted,
     val ansettelsesperiode: Ansettelsesperiode,
+    val ansettelsesdetaljer: List<Ansettelsesdetalj>? = null,
+)
+
+@Serializable
+internal data class Ansettelsesdetalj(
+    val yrke: Yrke? = null,
+    val avtaltStillingsprosent: Double? = null,
+)
+
+@Serializable
+internal data class Yrke(
+    val kode: String,
 )
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Arbeidsforhold.kt
@@ -19,6 +19,13 @@ internal data class Arbeidsforhold(
 internal data class AnsettelsesdetaljResponse(
     val yrke: Yrke? = null,
     val avtaltStillingsprosent: Double? = null,
+    val rapporteringsmaaneder: Rapporteringsmaaneder? = null,
+)
+
+@Serializable
+internal data class Rapporteringsmaaneder(
+    val fra: String? = null,
+    val til: String? = null,
 )
 
 @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/aareg/Arbeidsforhold.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 internal data class Arbeidsforhold(
     val arbeidssted: Arbeidssted,
     val ansettelsesperiode: Ansettelsesperiode,
-    val ansettelsesdetaljer: List<AnsettelsesdetaljResponse>? = null,
+    val ansettelsesdetaljer: List<AnsettelsesdetaljResponse>,
 )
 
 @Serializable

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
@@ -70,16 +70,16 @@ class AaregClientTest :
             response shouldContainExactly expectedAnsettelsesperioder
         }
 
-        test("hentAnsettelsesinfo gir ikke-tom liste med ansettelsesinfo") {
+        test("hentAnsettelsesforhold gir ikke-tom liste med ansettelsesinfo") {
             val mockAaregClient = mockAaregClient(HttpStatusCode.OK to MockResponse.arbeidsforhold)
 
-            val response = mockAaregClient.hentAnsettelsesinfo("22018520056", "call-id")
+            val response = mockAaregClient.hentAnsettelsesforhold("22018520056", "call-id")
 
-            val expectedAnsettelsesinfo =
+            val expectedAnsettelsesforhold =
                 mapOf(
                     Orgnr("896929119") to
                         setOf(
-                            Ansettelsesinfo(
+                            Ansettelsesforhold(
                                 startdato = 22.januar(2001),
                                 sluttdato = null,
                                 detaljer =
@@ -91,7 +91,7 @@ class AaregClientTest :
                                         ),
                                     ),
                             ),
-                            Ansettelsesinfo(
+                            Ansettelsesforhold(
                                 startdato = 15.mars(2001),
                                 sluttdato = null,
                                 detaljer = emptyList(),
@@ -99,10 +99,10 @@ class AaregClientTest :
                         ),
                 )
 
-            response shouldContainExactly expectedAnsettelsesinfo
+            response shouldContainExactly expectedAnsettelsesforhold
         }
 
-        test("hentAnsettelsesinfo filtrerer ut arbeidsforhold der arbeidsgiver ikke har gyldig orgnr") {
+        test("hentAnsettelsesforhold filtrerer ut arbeidsforhold der arbeidsgiver ikke har gyldig orgnr") {
             val orgnr = Orgnr.genererGyldig()
             val arbeidsforhold =
                 listOf(
@@ -118,17 +118,17 @@ class AaregClientTest :
 
             val mockAaregClient = mockAaregClient(HttpStatusCode.OK to arbeidsforhold.toJson(Arbeidsforhold.serializer().list()).toString())
 
-            val response = mockAaregClient.hentAnsettelsesinfo(Fnr.genererGyldig().verdi, "call-id")
+            val response = mockAaregClient.hentAnsettelsesforhold(Fnr.genererGyldig().verdi, "call-id")
 
-            val expectedAnsettelsesinfo =
+            val expectedAnsettelsesforhold =
                 mapOf(
                     orgnr to
                         setOf(
-                            Ansettelsesinfo(startdato = 3.januar(2021), sluttdato = 7.september(2021)),
+                            Ansettelsesforhold(startdato = 3.januar(2021), sluttdato = 7.september(2021)),
                         ),
                 )
 
-            response shouldContainExactly expectedAnsettelsesinfo
+            response shouldContainExactly expectedAnsettelsesforhold
         }
 
         test("kaster exception ved uventet JSON") {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
@@ -82,19 +82,13 @@ class AaregClientTest :
                             Ansettelsesforhold(
                                 startdato = 22.januar(2001),
                                 sluttdato = null,
-                                detaljer =
-                                    listOf(
-                                        Ansettelsesdetaljer(
-                                            yrkesKode = "1210147",
-                                            yrkesBeskrivelse = "STYRER (BARNEHAGE - OVER 9 ANSATTE - PRIVAT VIRKSOMHET)",
-                                            stillingsprosent = 100.0,
-                                        ),
-                                    ),
+                                yrkesKode = "1210147",
+                                yrkesBeskrivelse = "STYRER (BARNEHAGE - OVER 9 ANSATTE - PRIVAT VIRKSOMHET)",
+                                stillingsprosent = 100.0,
                             ),
                             Ansettelsesforhold(
                                 startdato = 15.mars(2001),
                                 sluttdato = null,
-                                detaljer = emptyList(),
                             ),
                         ),
                 )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
@@ -33,8 +33,16 @@ class AaregClientTest :
                 mapOf(
                     Orgnr("896929119") to
                         setOf(
-                            Periode(fom = 22.januar(2001), tom = null),
-                            Periode(fom = 15.mars(2001), tom = null),
+                            Ansettelsesinfo(
+                                periode = Periode(fom = 22.januar(2001), tom = null),
+                                yrkeskode = "1210147",
+                                stillingsprosent = 100.0,
+                            ),
+                            Ansettelsesinfo(
+                                periode = Periode(fom = 15.mars(2001), tom = null),
+                                yrkeskode = null,
+                                stillingsprosent = null,
+                            ),
                         ),
                 )
 
@@ -63,7 +71,7 @@ class AaregClientTest :
                 mapOf(
                     orgnr to
                         setOf(
-                            Periode(3.januar(2021), 7.september(2021)),
+                            Ansettelsesinfo(periode = Periode(3.januar(2021), 7.september(2021))),
                         ),
                 )
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
@@ -24,7 +24,7 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 class AaregClientTest :
     FunSpec({
 
-        test("gir ikke-tom liste med arbeidsforhold") {
+        test("hentAnsettelsesperioder gir ikke-tom liste med perioder") {
             val mockAaregClient = mockAaregClient(HttpStatusCode.OK to MockResponse.arbeidsforhold)
 
             val response = mockAaregClient.hentAnsettelsesperioder("22018520056", "call-id")
@@ -33,23 +33,15 @@ class AaregClientTest :
                 mapOf(
                     Orgnr("896929119") to
                         setOf(
-                            Ansettelsesinfo(
-                                periode = Periode(fom = 22.januar(2001), tom = null),
-                                yrkeskode = "1210147",
-                                stillingsprosent = 100.0,
-                            ),
-                            Ansettelsesinfo(
-                                periode = Periode(fom = 15.mars(2001), tom = null),
-                                yrkeskode = null,
-                                stillingsprosent = null,
-                            ),
+                            Periode(fom = 22.januar(2001), tom = null),
+                            Periode(fom = 15.mars(2001), tom = null),
                         ),
                 )
 
             response shouldContainExactly expectedAnsettelsesperioder
         }
 
-        test("filtrerer ut arbeidsforhold der arbeidsgiver ikke har gyldig orgnr") {
+        test("hentAnsettelsesperioder filtrerer ut arbeidsforhold der arbeidsgiver ikke har gyldig orgnr") {
             val orgnr = Orgnr.genererGyldig()
             val arbeidsforhold =
                 listOf(
@@ -71,11 +63,72 @@ class AaregClientTest :
                 mapOf(
                     orgnr to
                         setOf(
-                            Ansettelsesinfo(periode = Periode(3.januar(2021), 7.september(2021))),
+                            Periode(3.januar(2021), 7.september(2021)),
                         ),
                 )
 
             response shouldContainExactly expectedAnsettelsesperioder
+        }
+
+        test("hentAnsettelsesinfo gir ikke-tom liste med ansettelsesinfo") {
+            val mockAaregClient = mockAaregClient(HttpStatusCode.OK to MockResponse.arbeidsforhold)
+
+            val response = mockAaregClient.hentAnsettelsesinfo("22018520056", "call-id")
+
+            val expectedAnsettelsesinfo =
+                mapOf(
+                    Orgnr("896929119") to
+                        setOf(
+                            Ansettelsesinfo(
+                                startdato = 22.januar(2001),
+                                sluttdato = null,
+                                detaljer =
+                                    listOf(
+                                        Ansettelsesdetaljer(
+                                            yrkesKode = "1210147",
+                                            yrkesBeskrivelse = "STYRER (BARNEHAGE - OVER 9 ANSATTE - PRIVAT VIRKSOMHET)",
+                                            stillingsprosent = 100.0,
+                                        ),
+                                    ),
+                            ),
+                            Ansettelsesinfo(
+                                startdato = 15.mars(2001),
+                                sluttdato = null,
+                                detaljer = emptyList(),
+                            ),
+                        ),
+                )
+
+            response shouldContainExactly expectedAnsettelsesinfo
+        }
+
+        test("hentAnsettelsesinfo filtrerer ut arbeidsforhold der arbeidsgiver ikke har gyldig orgnr") {
+            val orgnr = Orgnr.genererGyldig()
+            val arbeidsforhold =
+                listOf(
+                    Arbeidsforhold(
+                        Arbeidssted(ArbeidsstedType.UNDERENHET, listOf(Ident(IdentType.ORGANISASJONSNUMMER, orgnr.verdi))),
+                        Ansettelsesperiode(startdato = 3.januar(2021), sluttdato = 7.september(2021)),
+                    ),
+                    Arbeidsforhold(
+                        Arbeidssted(ArbeidsstedType.PERSON, listOf(Ident(IdentType.FOLKEREGISTERIDENT, "12345678901"))),
+                        Ansettelsesperiode(startdato = 8.juni(2021), sluttdato = 8.juli(2021)),
+                    ),
+                )
+
+            val mockAaregClient = mockAaregClient(HttpStatusCode.OK to arbeidsforhold.toJson(Arbeidsforhold.serializer().list()).toString())
+
+            val response = mockAaregClient.hentAnsettelsesinfo(Fnr.genererGyldig().verdi, "call-id")
+
+            val expectedAnsettelsesinfo =
+                mapOf(
+                    orgnr to
+                        setOf(
+                            Ansettelsesinfo(startdato = 3.januar(2021), sluttdato = 7.september(2021)),
+                        ),
+                )
+
+            response shouldContainExactly expectedAnsettelsesinfo
         }
 
         test("kaster exception ved uventet JSON") {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/aareg/AaregClientTest.kt
@@ -48,10 +48,12 @@ class AaregClientTest :
                     Arbeidsforhold(
                         Arbeidssted(ArbeidsstedType.UNDERENHET, listOf(Ident(IdentType.ORGANISASJONSNUMMER, orgnr.verdi))),
                         Ansettelsesperiode(startdato = 3.januar(2021), sluttdato = 7.september(2021)),
+                        listOf(AnsettelsesdetaljResponse()),
                     ),
                     Arbeidsforhold(
                         Arbeidssted(ArbeidsstedType.PERSON, listOf(Ident(IdentType.FOLKEREGISTERIDENT, "12345678901"))),
                         Ansettelsesperiode(startdato = 8.juni(2021), sluttdato = 8.juli(2021)),
+                        listOf(AnsettelsesdetaljResponse()),
                     ),
                 )
 
@@ -103,10 +105,12 @@ class AaregClientTest :
                     Arbeidsforhold(
                         Arbeidssted(ArbeidsstedType.UNDERENHET, listOf(Ident(IdentType.ORGANISASJONSNUMMER, orgnr.verdi))),
                         Ansettelsesperiode(startdato = 3.januar(2021), sluttdato = 7.september(2021)),
+                        listOf(AnsettelsesdetaljResponse()),
                     ),
                     Arbeidsforhold(
                         Arbeidssted(ArbeidsstedType.PERSON, listOf(Ident(IdentType.FOLKEREGISTERIDENT, "12345678901"))),
                         Ansettelsesperiode(startdato = 8.juni(2021), sluttdato = 8.juli(2021)),
+                        listOf(AnsettelsesdetaljResponse()),
                     ),
                 )
 

--- a/src/test/resources/aareg-arbeidsforhold.json
+++ b/src/test/resources/aareg-arbeidsforhold.json
@@ -35,6 +35,15 @@
     "ansettelsesperiode": {
       "startdato": "2001-01-22"
     },
+    "ansettelsesdetaljer": [
+      {
+        "yrke": {
+          "kode": "1210147",
+          "beskrivelse": "STYRER (BARNEHAGE - OVER 9 ANSATTE - PRIVAT VIRKSOMHET)"
+        },
+        "avtaltStillingsprosent": 100.0
+      }
+    ],
     "rapporteringsordning": {
       "kode": "A_ORDNINGEN",
       "beskrivelse": "Rapportert via a-ordningen (2015-d.d.)"

--- a/src/test/resources/aareg-arbeidsforhold.json
+++ b/src/test/resources/aareg-arbeidsforhold.json
@@ -38,10 +38,25 @@
     "ansettelsesdetaljer": [
       {
         "yrke": {
+          "kode": "9999999",
+          "beskrivelse": "GAMMEL STILLING"
+        },
+        "avtaltStillingsprosent": 50.0,
+        "rapporteringsmaaneder": {
+          "fra": "2001-01",
+          "til": "2020-12"
+        }
+      },
+      {
+        "yrke": {
           "kode": "1210147",
           "beskrivelse": "STYRER (BARNEHAGE - OVER 9 ANSATTE - PRIVAT VIRKSOMHET)"
         },
-        "avtaltStillingsprosent": 100.0
+        "avtaltStillingsprosent": 100.0,
+        "rapporteringsmaaneder": {
+          "fra": "2021-01",
+          "til": null
+        }
       }
     ],
     "rapporteringsordning": {

--- a/src/test/resources/aareg-arbeidsforhold.json
+++ b/src/test/resources/aareg-arbeidsforhold.json
@@ -102,6 +102,14 @@
     "ansettelsesperiode": {
       "startdato": "2001-03-15"
     },
+    "ansettelsesdetaljer": [
+      {
+        "rapporteringsmaaneder": {
+          "fra": "2001-03",
+          "til": null
+        }
+      }
+    ],
     "rapporteringsordning": {
       "kode": "A_ORDNINGEN",
       "beskrivelse": "Rapportert via a-ordningen (2015-d.d.)"


### PR DESCRIPTION
Tar med flere felter fra aareg responsen, slik at vi kan vise flere arbeidsforhold i faisu oversikten i inntektsmelding skjema.
La.

Legger til en ny funksjon `hentAnsettelsesforhold()` som returnerer ansettelsesperioder med tilhørende detaljer (yrkeskode, yrkesbeskrivelse, stillingsprosent) fra Aareg.